### PR TITLE
Rotation + camera

### DIFF
--- a/Major Project/code/myJs/matrices.js
+++ b/Major Project/code/myJs/matrices.js
@@ -49,11 +49,13 @@ function updateAttributesAndUniforms(){
 
 
 var playerYRotation;
+var playerXRotation;
 
 var playerX = 0, 
 	playerY = 0, 
 	playerZ = 0;
 
+var cameraSpeed = 0.003;
 
 //Matrix for camera
 //Move the camera in the world

--- a/Major Project/code/myJs/mouse.js
+++ b/Major Project/code/myJs/mouse.js
@@ -9,6 +9,7 @@ document.exitPointerLock = document.exitPointerLock    ||
 							document.mozExitPointerLock;
 
 var pointerLocked = false;
+
 							
 canvas.addEventListener('mousedown', function(){
 	
@@ -30,44 +31,32 @@ canvas.addEventListener('mousedown', function(){
 	
 });
 
-var globalRotateX = 0;
+
+
+
 var currentRotateY = 0;
+var currentRotateX = 0;
 var rotateSpeed = 0.3;
+
+var prevX = 0;
+var prevY = 0;
 
 canvas.addEventListener('mousemove', function(e){
 	if(pointerLocked === true){
-		//console.log("moved!");
-		
-		//rotateX = MDN.rotateXMatrix(e * 0.5);
-		//updateAtt
-		//console.log("Client y is: " + e.); //works more if unlocked
-
-		
 		/*
 		X and Y are kinda reversed here, because you move mouse on the X, to rotate terrain in Y
 		*/
-		currentRotateY -= e.movementX;
-		//console.log("CurrentRotateY is: " + currentRotateY);
-		
-		/*
-		Updates rotation matrix
-		
-		Defined in matrices.js
-		*/
+		//Horizontal
+		var currentXMovement = e.movementX;
+		currentRotateY += currentXMovement + prevX;//e.movementX;
+		prevX = currentXMovement;
 		playerYRotation = currentRotateY * rotateSpeed;
 		
-
-		/*
-		THIS DOESNT DRAW THE TERRAIN IT JUST UPDATES THE ROTATE VALUES
-		THE DRAW TERRAIN FUNCTION DRAWS IT
-		*/
-		
-		
-		/*
-		Right now, its rotating around the origin
-		Instead you want to rotate around the player position or something
-		*/
-		
+		//Vertical
+		var currentYMovement = e.movementY;
+		currentRotateX += currentYMovement + prevY;
+		prevY = currentYMovement;
+		playerXRotation = currentRotateX * rotateSpeed;
 	}
 });
 							

--- a/Major Project/code/myJs/terrain.js
+++ b/Major Project/code/myJs/terrain.js
@@ -216,146 +216,28 @@ gl.vertexAttribPointer(colorAttribLocation, 3, gl.FLOAT, false, 0, 0);
 Draw the terrain
 */
 function drawTerrain(){
-	//Position the terrain
-	//computeModelMatrix(now/5, -115, -20, -150, 10);//old
+
 	var now = Date.now(); //For rotating stuff
-	
-	//translate to player position, then rotate, and translate back?
-	
-	//computeModelMatrix(globalRotateX, globalRotateY , 0, terrainX, terrainY, terrainZ, terrainScale);
-
-	
-	
-	//move origin matrix//computeTranslateMatrix(0, 10, 0);
-	
-	/*
-	I cant get it to change pivot point.
-	
-	Do you ever change matrix multiplication order?
-		Should be: scale, rotate, translate
-	
-	Is there a way to pass in a vector as well as an angle?
-	*/
-	
-	
-	//Set matrices, it is just replacing them?
-	
-	
-	
-	/*
-	Maybe want to rotate around the terrains CENTER
-	
-	terrainX, terrainY, terrainZ is its bottom corner, so add like terrainSize/2?
-		maybe need to take into account terrain scale as well
-
-	terrainX corresponding to terrainRows might be wrong
-	vice verase with terrainZ corresponding to terrainColumns
-	
-	Keep terrains coordinates the same?
-		-and move the player instead?
-	*/
-	/*
-	var movePivotMatrix = [	   
-		1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   -playerX, -playerY, -playerZ, 1];
-	var removePivotMatrix = [	   
-		1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   playerX, playerY, playerZ, 1];
-	  */
-	  
-	  /*
-	  	var movePivotMatrix = [	   
-		1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   -0, -0, -0, 1];
-	var removePivotMatrix = [	   
-		1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   0, 0, 0, 1];
-	  */
-	  
-	   /*
-	   var movePivotMatrix = [
-			1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   0,    0,    0,   1
-	   ];
-	   
-	   	   var removePivotMatrix = [
-			1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	   0,    0,    0,   1
-	   ];
-	*/
-		/*
-		var movePivotMatrix = [	   
-		1,    0,    0,   0,
-	    0,    1,    0,   0,
-	    0,    0,    1,   0,
-	    -terrainX + terrainRows/2,    terrainY,    -terrainZ + terrainColumns/2,   1];
-		*/
-		
-	//computeScaleMatrix(terrainScale, terrainScale, terrainScale);	
-	//computeRotationYMatrix(globalRotateY);
-	//computeTranslateMatrix(terrainX, terrainY, terrainZ);
-	//computeTranslateMatrix(playerX, playerY, playerZ);
-	//updateAttributesAndUniforms();
-	//updateAttributesAndUniformsRotation(movePivotMatrix, removePivotMatrix);
-	
-	/*
-	This is the position the camera looks at
-	So use globalRotateY here? or the renamed version?
-	
-	Make yRotation from -1 to +1?
-	*/
-	
-	//console.log("global rotate y/0.0003 is: " + playerYRotation*0.03);
-	cameraTarget = [
-		playerYRotation*0.03, //rotates left/right, set this to use globalRotateY?
-		0,
-		1,
-	];
 	
 	scale = m4.scaling(terrainScale, terrainScale, terrainScale)
 	xRotation = m4.xRotation(0);
 	yRotation = m4.yRotation(0);
 	zRotation = m4.zRotation(0);
 	//'works' with playerX, Y, Z, but it shouldnt need to
-	position = m4.translation(playerX, playerY, playerZ); //0, -2, -5 to see it
+	position = m4.translation(terrainX, terrainY, terrainZ); //0, -2, -5 to see it
+	//console.log("Terrain X: " + terrainX);
+	//console.log("Terrain Y: " + terrainY);
+	//console.log("Terrain Z: " + terrainZ);
 	//terrainX, terrainY, terrainZ
+	//playerX, playerY, playerZ
 	
-	/*
-	cameraPosition should be changed based on rotation?
-	playerPositions is the origin of the camera?
-	*/
-	cameraMatrix = m4.translate(cameraMatrix, playerX, playerY, playerZ);
-	cameraMatrix = m4.lookAt(cameraPosition, cameraTarget, UP_VECTOR);
-	//console.log("camera TARGET: " + cameraTarget);
-	viewMatrix = m4.inverse(cameraMatrix);
-	viewProjectionMatrix = m4.multiply(projectionMatrix, viewMatrix);
-	
+	//console.log("Player X: " + playerX);
+	//console.log("Player Y: " + playerY);
+	//console.log("Player Z: " + playerZ);
 	
 	//Times matrices together
 	updateAttributesAndUniforms();
-	
-	//updateAttributesAndUniformsRotation();
-	
-	
-	/*
-	Matrices are just getting overwritten....
-	*/
-	//computeModelMatrix(0, globalRotateY, 0, -terrainX, -terrainY, -terrainZ, terrainScale);
-	//computeModelMatrix(0, globalRotateY, 0, -terrainX, -terrainY, -terrainZ, terrainScale);
-	//updateAttributesAndUniforms();
-	
+
 	
 	//Vertices
 	gl.bindBuffer(gl.ARRAY_BUFFER, positions);

--- a/Major Project/index.html
+++ b/Major Project/index.html
@@ -262,7 +262,7 @@ function render(){
 	/*
 	CHANGE GETCURRENTHEIGHT TO MOVE THE PLAYER NOT THE TERRAIN
 	*/
-	getCurrentHeight();
+	//getCurrentHeight();
 	
 	//console.log("Player x: " + playerX + ", " + playerY + ", " + playerZ);
 	//console.log("Terrain x: " + terrainX + ", " + terrainY + ", " + terrainZ);
@@ -292,59 +292,79 @@ function render(){
 //var playerY = 0;
 //var playerZ = 0;
 
-
+/*
+Add cameras rotation onto its position?
+*/
 //Move this into movement file when done
 var movementSpeed = 0.1;
 function movePlayer(){
 
-	//move them in the cameras direction?
-	//need to do playerXYZ = cameraXYZ in one call?
-
 	if(moveUp === true){
-		//Then move the entire world down etc
-		//console.log("Moving up");
-		//terrainY -= movementSpeed;
-		playerY -= movementSpeed;
-		
-	
- 
+		playerY += movementSpeed;
 	}
 	else if(moveDown === true){
-		//console.log("Moving down");
-		//terrainY += movementSpeed;
-		playerY += movementSpeed;
-	
-	}
-	else if(moveLeft === true){
-		//console.log("Moving left");
-		//terrainX += movementSpeed;
-		playerX -= movementSpeed;
-		
-	}
-	else if(moveRight === true){
-		//console.log("Moving right");
-		//terrainX -= movementSpeed;
-		playerX += movementSpeed;
-	
+		playerY -= movementSpeed;
 	}
 	else if(moveForward === true){
-		//console.log("Moving forward");
-		//terrain.setZ(terrain.getZ()+1) 
-		//need a function to get all of the objects in the world's X pos, and shift them
-		//getWorldState.x = getWorldState.x - 1
-		//terrainZ += movementSpeed;
-		playerZ -= movementSpeed;
-	
+		//playerZ += movementSpeed;
+		
+		playerX -= (cameraPosition[0] - cameraTarget[0]) //+ 5;// - movementSpeed;
+		//playerY += (cameraPosition[1] + cameraTarget[1])/10 //+ 5;// - movementSpeed;
+		playerZ -= (cameraPosition[2] - cameraTarget[2]) //+ 5;// - movementSpeed;
+		
 	}
 	else if(moveBack === true){
 		//console.log("Moving backward");
 		//terrainZ -= movementSpeed;
-		playerZ += movementSpeed;
-	
+		playerZ -= movementSpeed;
 	}
 	else{
 	
 	}
+	
+	/*
+	THIS IS THE LINE THATS BREAKING EVERYTHING (m4.translate)
+	*/
+	cameraMatrix = m4.yRotation(0); //stops it wildy spinning at least
+	cameraMatrix = m4.translate(cameraMatrix, playerX, playerY, playerZ);
+	
+	/*
+	xPos = sin(y rotation in radians)
+	yPos = sin(x rotation in radians)
+	zPos = cos(y rotation in radians)
+	
+	playerYRotation is the angle I rotated
+	
+	I think camera target is too small, its a unit vector or something
+	Its always in range 0->1, therefore camera always looks there :/
+	
+	I've added the camera position to it to fix it
+	*/
+	cameraTarget = [
+		cameraMatrix[12] + Math.sin(playerYRotation * cameraSpeed), 
+		cameraMatrix[13] + Math.sin(playerXRotation * cameraSpeed),
+		cameraMatrix[14] + Math.cos(playerYRotation * cameraSpeed),
+	];
+	
+		
+	cameraPosition = [
+		cameraMatrix[12], //playerX?
+		cameraMatrix[13],
+		cameraMatrix[14]
+		//playerX,
+		//playerY,
+		//playerZ
+	];
+	
+	console.log("Camera position z: " + cameraMatrix[14]);
+	console.log("Player z: " + playerZ);
+		
+	cameraMatrix = m4.lookAt(cameraPosition, cameraTarget, UP_VECTOR);
+	console.log("camera TARGET: " + cameraTarget);
+	viewMatrix = m4.inverse(cameraMatrix);
+	viewProjectionMatrix = m4.multiply(projectionMatrix, viewMatrix);
+	//Times matrices together
+	updateAttributesAndUniforms();
 	
 }
 


### PR DESCRIPTION
Camera class wasn't working at all, the terrain now renders at its own
position, rather than being based off the players position.

Also fixed camera rotation, it goes 360 degrees now

Removed the rover going left/right as it doesnt make sense. Instead, the
user can turn the camera and move forward to have the same effect.

Cleaned up some files.